### PR TITLE
BOT-346 Fix null returns from errors

### DIFF
--- a/Getit.sln.DotSettings
+++ b/Getit.sln.DotSettings
@@ -1,0 +1,8 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Carlabs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=getit/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=graphql/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=int_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Param_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subselect/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subselection/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ which can also contain nested data types, so you can have an list of strings
 and such nested structures.
 
 These C# types are supported:
-* string 
-* int
-* float
-* double
-* EnumHelper (For enumerated types)
-* KeyValuePair<string, object>
-* IList<object>
-* IDictionary<string, object>
+* `string`
+* `int`
+* `float`
+* `double`
+* `EnumHelper` (For enumerated types)
+* `KeyValuePair<string, object>`
+* `IList<object>`
+* `IDictionary<string, object>`
 
 #### A more complex example with nested parameter data types
 ```csharp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) ![VSTS Build Status](https://carlabs.visualstudio.com/Getit/_apis/build/status/Getit-PR)
+
+
 <p align="center"><img src= "getit-logo-640x.png"></img></p>
 
 # Getit

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use it for passing anything you might create right on through.
 * **V2.x.x** - Updated Get() method so it will now throw an exception 
 on any error. Previously would return `null`. This has some implications on 
 error handeling when sending multiple queries. If any fail,
-an exception is now raised. See error handeling above. This is a breaking change 
+an exception is now raised. See error handeling section. This is possibly a breaking change 
 from V1.
 * **v1.x.x** - Initial Release
 
@@ -403,7 +403,7 @@ It uses the data type to determine how to build the query so in cases where you 
 GraphQL enumerations their is a simple helper class that can be used.
 
 Example how to generate an Enumeration
-```C#
+```csharp
 EnumHelper GqlEnumEnabled = new EnumHelper().Enum("ENABLED");
 EnumHelper GqlEnumDisabled = new EnumHelper("DISABLED");
 EnumHelper GqlEnumConditionNew = new EnumHelper("NEW");
@@ -443,7 +443,7 @@ in response to error situations. For client errors, empty data or
 any graphQL related errors an exception will be throw. Additional data based on 
 the exception will be stored in the thrown exception.
 
-```C#
+```csharp
 using GraphQL.Common.Response;
 
 // Setup Getit, config and a couple of queries

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ to pass a raw or prebuilt query to the GraphQL server. This is acomplished by us
 In this example we have on the server a query that responds to a `Version` number request.
 
 The GraphQL JSON response from the `Make` query would look like this -
-```C#
+```json
 {
   "Make": [
     {
@@ -271,10 +271,11 @@ The GraphQL JSON response from the `Make` query would look like this -
       "name": "aston martin"
     }
   ]
-}```
+}
+```
 
 #### Example RAW query code
-```C#
+```csharp
     // Create an instance of Getit and the Config
     Getit getit = new Getit();
     Config config = new Config();

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Currently Getit only builds queries and does not help with mutations. Getit
 does allow for passing a *Raw* query to your server so you can
 use it for passing anything you might create right on through. 
 
+## Change Log
+* **V2.x.x** - Updated Get() method so it will now throw an exception 
+on any error. Previously would return `null`. This has some implications on 
+error handeling when sending multiple queries. If any fail,
+an exception is now raised. See error handeling above. This is a breaking change 
+from V1.
+* **v1.x.x** - Initial Release
 
 ## Installation
 Install from Nuget, or your IDE's package manager
@@ -435,46 +442,73 @@ This will generate a query that looks like this (well part of it anyway)
 }
 ```
 ### Handeling Errors
-Their are a few types of errors, generally no data, service issues, etc all will
-return a `null` from the Get() call. In addition to transport type of errors you may
-encounter GraphQL query syntax errors. These are generally shipped back as part of the JSON response.
-In some cases you may have some valid response data or a mixture of both response data and 
-GraphQL errors. Getit will try to pick off the Error's and stuff them into the Query's 
-`GqlErrors` structure. Also invalid JSON type conversions will generally cause an exception.
+**Getit version 2.X Error Handeling**
+Changed for version 2 onwards the Get() method will no longer return `null` 
+in response to error situations. For client errors, empty data or 
+any graphQL related errors an exception will be throw. Additional data based on 
+the exception will be stored in the thrown exception.
 
-**~NOTE: Currently a failed request to the server (or any exceptions from the GQLClient) 
-returns `null`. This may change to allow the exception to bubble up. In your code
-plan on catching any exceptions as well as checking for a `null` response.~**
-
-Here is an example how to check for GraphQL errors
 ```C#
-...
-if (nearestDealerQuery.HasErrors())
+using GraphQL.Common.Response;
+
+// Setup Getit, config and a couple of queries
+
+Config config = new Config("https://randy.butternubs.com/graphql");
+Getit getit = new Getit(config);
+IQuery userQuery = getit.Query();
+
+userQuery
+    .Name("User")
+    .Select("userId", "firstName", "lastName", "phone")
+    .Where("userId", "331")
+    .Where("lastName", "Calhoon")
+    .Comment("My First Getit Query");
+
+// Fire the request to the sever catch any issues
+// Check the GraphQL client for list of it's possible exceptions.
+// Get it will also throw `ArgumentException` and `ArgumentNullException`
+
+try
 {
-    // scan all errors
-    foreach (GraphQLError gqlErr in nearestDealerQuery.GqlErrors)
+    string resp = await getit.Get<string>(userQuery);
+}
+catch(Exception ex)
+{
+    // Exceptions can OPTIONALLY have additional data depending on the cause
+
+    // "request"  - String of query set to server
+    if (e.Data.Contains("request"))
     {
-        Console.WriteLine("Error : " + gqlErr.Message);
-        
-        // For details scan the locations if desired
-        foreach (GraphQLLocation loc in gqlErr.Locations)
+
+        Console.WriteLine("Found Request Query");
+        Console.WriteLine(e.Data["request"]);
+    }
+
+    // "gqlErrors" - Array of GraphQLError's
+    if (e.Data.Contains("gqlErrors"))
+    {
+        Console.WriteLine("Found gqlErrors");
+
+        // Note data type returned is an Aarry of GraphQLError
+        GraphQLError [] errs = (GraphQLError []) e.Data["gqlErrors"];
+
+        foreach (GraphQLError err in errs)
         {
-            Console.WriteLine("  -->Location Line : " + loc.Line + ", Column : " + loc.Column);
+            // Look at any of the elements in the error, here just the message
+            Console.WriteLine(err.Message);
         }
     }
 }
-else
-{
-    Console.WriteLine("No Errors Found");
-}
 ...
+
 ```
+
+
 ## Todo's
 * Test on more then the single GraphQL server we use
-* GraphQLClient error handeling - to throw or now
 * Expose More GraphQLClient functionality
 * Stuff that is broken as it is discovered
 * Mutations if needed
 * Other missing GQL support
 * More Organized Docs
-* Publish on Nuget
+

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ from V1.
 
 ## Installation
 Install from Nuget, or your IDE's package manager
-> Install-Package Carlabs.Getit
+```
+Install-Package Carlabs.Getit
+```
 
 Supports:
 * .NET Standard 1.3
 
 ## Usage
-```C#
+```csharp
 // Setup Getit, config and a couple of queries
 
 Config config = new Config("https://randy.butternubs.com/graphql");
@@ -60,7 +62,7 @@ Also LOOK AT THE SOURCE for additional parameter, features that
 may have not been covered here!
 
 Let's breakdown a simple GraphQL query and write it in Getit's querybuilder.
-```C#
+```csharp
 {
     NearestDealer(zip: "91403", make: "aston martin") {
     distance
@@ -81,7 +83,7 @@ This query has a simple set of parameters, and a select field, along with what I
 Both are of string type, although they can be any GraphQL type including enums.
 
 Now lets write this with the Getit Querybuilder
-```C#
+```csharp
 subSelectDealer
     .Name("Dealer")
     .Select("name", "address", "city", "state", "zip", "phone");
@@ -96,7 +98,7 @@ nearestDealerQuery
 ```
 It's pretty straight forward. You can also pass in dictionary type objects to both the `Select` and 
 the `Where` parts of the statement. Here is another way to write the same query -
-```C#
+```csharp
 Dictionary<string, object> whereParams = new Dictionary<string, object>
 {
     {"make", "aston martin"},
@@ -114,19 +116,18 @@ When appropriate (You figure it out) you can use the following data types,
 which can also contain nested data types, so you can have an list of strings 
 and such nested structures.
 
-These C# types are supported -
+These C# types are supported:
 * string 
 * int
 * float
 * double
 * EnumHelper (For enumerated types)
-* KeyValuePair < string, object >
-* IList < object >
-* IDictionary < string, object >
+* KeyValuePair<string, object>
+* IList<object>
+* IDictionary<string, object>
 
 #### A more complex example with nested parameter data types
-```C#
-...
+```csharp
 // Create a List of Strings for passing as an ARRAY type parameter
 List<string> modelList = new List<string>(new[] {"DB7", "DB9", "Vantage"});
 List<object> recList = new List<object>(new object[] {"rec1", "rec2", "rec3"});
@@ -171,7 +172,6 @@ query
     .Where("id_double", 3.25)
     .Where("id_string", "some_sting_id")
     .Comment("A complicated GQL Query with getit");
-...
 ```
 So as you can see you can express parameters as list or objects, and nested as well. 
 since this is a made up example your mileage may vary if you type in the code, but give
@@ -182,40 +182,40 @@ Their are a coupe of ways to set up Getit for use. Here are a few that are all
 basically the same. Getit will allow a class config to be set, or you can set it 
 per-call to the Get().
 
-```#C#
+```csharp
     // Create an instance of Getit, set it directly with the Config
     Config config = new Config("http://haystack.calhoon.com");
     IGetit getit = new Getit(config);
-...    
+
     // Create without a config (must pass config to Get())
     IGetit getit = new Getit();
-...
+
     // Or if you want create Getit and set config
     IGetit getit = new Getit();
-    ...
+
     // Defer setting the configuration 
     IConfig config = new Config("http://haystack.calhoon.com");
     getit.Config = config;
-...    
+
     // Getting a new query via the Dispenser (Factory)
     IQuery aQuery = getit.Query();
     
     // You could also just have done this 
     // IQuery aQuery = new Query()
-...
+
     // You can use the Getit's instance's config if set
     // to eliminate extra params when calling the Get().
 
     // Exectue the query, notice that CONFIG is not required
     JObject jOb = await getit.Get<JObject>(aQuery);
-...
+
     // If you don't want to set or use Getit's instance config 
     // just pass it with each Get() call
     JObject jOb = await getit.Get<JObject>(aQuery, config);
 ```
 
 ### Multiple `Query` Query
-```C#
+```csharp
 // Setup Getit, and a couple of queries
 Getit getit = new Getit();
 Config config = new Config();
@@ -295,7 +295,7 @@ The GraphQL JSON response from the `Make` query would look like this -
     Console.WriteLine(jOb);
 ```
 #### RAW Example Console Output
-```JSON
+```json
 {
   "data": {
     "Alias": [
@@ -314,17 +314,13 @@ Getit supports that functionality and it can save extra network requests. Essent
 you can pass any generated query to the `Batch()` method and it will be stuffed into
 the call. Using JObject's or JSON string returns from `Get()` is usually how you get the 
 blob of data back from batched queries.
-```C#
-...
-
+```csharp
 nearestDealerQuery
     .Name("NearestDealer")
     .Select("distance")
     .Select(subSelectDealer)
     .Where("zip", "91302")
     .Where("make", "aston martin");
-
-...
 
 batchQuery.Raw("{ Version }");          // Get the version
 batchQuery.Batch(nearestDealerQuery);   // Batch up the nearest dealer query
@@ -342,7 +338,7 @@ just be different. Getit allows the support for aliases. The proper name of the
 query should be set in the Name() method, but additionally you can add an `Alias()` call
 to set that. So back to a simple example query with an alias-
 
-```C#
+```csharp
 {
     AstonNearestDealer:NearestDealer(zip: "91403", make: "aston martin") {
     distance
@@ -363,7 +359,7 @@ This query has a simple set of parameters, and a select field, along with what I
 Both are of string type, although they can be any GraphQL type including enums.
 
 Now lets write this with the Getit Querybuilder
-```C#
+```csharp
 subSelectDealer
     .Name("Dealer")
     .Select("name", "address", "city", "state", "zip", "phone");
@@ -378,7 +374,7 @@ nearestDealerQuery
     .Where("make", "aston martin");
 ```
 The response (JObject) would be something like this -
-```JSON
+```json
 {
   "AstonNearestDealer": [
     {
@@ -391,9 +387,6 @@ The response (JObject) would be something like this -
         "zip": "91302",
         "phone": "(818) 887-7111",
       }
-    },
-    {
-        ...
     }
   ]
 }
@@ -415,8 +408,7 @@ EnumHelper GqlEnumConditionUsed = new EnumHelper("USED");
 ```
 
 Example creating a dictionary for a select (GraphQL Parameters)
-```C#
-...
+```csharp
 Dictionary <string, object> mySubDict = new Dictionary<string, object>;
 {
     {"Make", "aston martin"},
@@ -431,7 +423,7 @@ query.Name("CarStats")
     .Comment("Using Enums");
 ```
 This will generate a query that looks like this (well part of it anyway)
-```C#
+```csharp
 {
     CarStats(Make:"aston martin", Model:"DB7GT", Condition:NEW, _debug:DISABLED)
     { 

--- a/Source/Carlabs.Getit/.nuspec
+++ b/Source/Carlabs.Getit/.nuspec
@@ -2,7 +2,7 @@
 <package  xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Getit</id>
-    <version>1.00</version>
+    <version>2.00</version>
     <title>GraphQL Query Builder</title>
     <authors>Sandy Ganz</authors>
     <owners>CarLabs</owners>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Getit is a GraphQL Query builder. It helps build queries with a simple syntax and allows complex structures to be easily defined.</description>
     <releaseNotes>Initial Release</releaseNotes>
-    <copyright>(C) 2018 CarLabs</copyright>
+    <copyright>(C) 2019 CarLabs</copyright>
     <tags>GraphQL, REST, API</tags>
     <dependencies>
       <dependency id="" />

--- a/Source/Carlabs.Getit/Carlabs.Getit.csproj
+++ b/Source/Carlabs.Getit/Carlabs.Getit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>7.2</LangVersion>
+    <Version>2.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GraphQL.Client" Version="1.0.3" />

--- a/Source/Carlabs.Getit/EnumHelper.cs
+++ b/Source/Carlabs.Getit/EnumHelper.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Helper class that will allow us to pass a string but
     /// keep the idea that it's really a non-quoted ENUM in the
-    /// gQL relm. So the idea would be to pass this as a param
+    /// gQL realm. So the idea would be to pass this as a param
     /// value not a string and it will be rendered without being
     /// quoted
     /// </summary>
@@ -11,7 +11,7 @@
     /// Creating Instance -
     ///     EnumHelper GqlEnumEnabled = new EnumHelper().Enum("ENABLED");
     ///     EnumHelper GqlEnumDisabled = new EnumHelper("DISABLED");
-    ///     GqlEnumDisabled.Enum("SOMETHNG_ENUM");
+    ///     GqlEnumDisabled.Enum("SOMETHING_ENUM");
     ///
     /// In use -
     ///     Creating a Dictionary for a Select (gQL Parameters)

--- a/Source/Carlabs.Getit/Getit.cs
+++ b/Source/Carlabs.Getit/Getit.cs
@@ -29,7 +29,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Set up anything needed, in this case we can
-        /// optionally passin the config that will be useful
+        /// optionally passing the config that will be useful
         /// for subsequent Get() calls if not supplied.
         /// </summary>
         /// <param name="config"></param>
@@ -40,7 +40,7 @@ namespace Carlabs.Getit
 
         /// <inheritdoc />
         /// <summary>
-        /// The Query Factory/Dispenser. These are independant
+        /// The Query Factory/Dispenser. These are independent
         /// of connection so you can create a bunch and use them
         /// for sub-queries, etc.
         /// </summary>
@@ -60,7 +60,7 @@ namespace Carlabs.Getit
         /// <typeparam name="T">Data Type, typically a list of the record but not always.
         /// </typeparam>
         /// <param name="query"></param>
-        /// <param name="resultName">Overide of the Name/Alias of the query</param>
+        /// <param name="resultName">Override of the Name/Alias of the query</param>
         /// <returns>The type of object stuffed with data from the query</returns>
         /// <exception cref="ArgumentException">Dupe Key, missing parts or empty parts of a query</exception>
         public async Task<T> Get<T>(IQuery query, string resultName = null)
@@ -79,7 +79,7 @@ namespace Carlabs.Getit
         /// </typeparam>
         /// <param name="query"></param>
         /// <param name="config"></param>
-        /// <param name="resultName">Overide of the Name/Alias of the query</param>
+        /// <param name="resultName">Override of the Name/Alias of the query</param>
         /// <returns>The type of object stuffed with data from the query</returns>
         /// <exception cref="ArgumentException">Dupe Key, missing parts or empty parts of a query</exception>
         /// <exception cref="ArgumentNullException">Invalid Configuration</exception>
@@ -144,14 +144,14 @@ namespace Carlabs.Getit
 
             // Now we need to get the results name. This is EITHER the Name, or the Alias
             // name. If Alias was set then use it. If the user does specify it in
-            // the Get call it's an overide. This might be needed with raw query
+            // the Get call it's an override. This might be needed with raw query
 
             if (resultName == null)
             {
                 resultName = string.IsNullOrWhiteSpace(query.AliasName) ? query.QueryName : query.AliasName;
             }
 
-            // Let the client do the mapping , all sorts of things can thow at this point!
+            // Let the client do the mapping , all sorts of things can throw at this point!
             // caller should check for exceptions, Generally invalid mapping into the type
 
             return gqlResp.GetDataFieldAs<T>(resultName);

--- a/Source/Carlabs.Getit/IGetit.cs
+++ b/Source/Carlabs.Getit/IGetit.cs
@@ -27,7 +27,7 @@ namespace Carlabs.Getit
         /// <typeparam name="T">Data Type, typically a list of the record but not always.
         /// </typeparam>
         /// <param name="query">Created Query</param>
-        /// <param name="resultName">Overide of the Name/Alias of the query</param>
+        /// <param name="resultName">Override of the Name/Alias of the query</param>
         /// <returns>The type (T) of object stuffed with data from the query</returns>
         /// <exception cref="ArgumentException">Dupe Key</exception>
         Task<T> Get<T>(IQuery query, string resultName = null);
@@ -43,7 +43,7 @@ namespace Carlabs.Getit
         /// </typeparam>
         /// <param name="query">Created Query</param>
         /// <param name="config">Configuration</param>
-        /// <param name="resultName">Overide of the Name/Alias of the query</param>
+        /// <param name="resultName">Override of the Name/Alias of the query</param>
         /// <returns>The type (T) of object stuffed with data from the query</returns>
         /// <exception cref="ArgumentException">Dupe Key</exception>
         Task<T> Get<T>(IQuery query, IConfig config, string resultName = null);

--- a/Source/Carlabs.Getit/IQuery.cs
+++ b/Source/Carlabs.Getit/IQuery.cs
@@ -22,7 +22,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Accepts a string and will use this as the query. Setting
-        /// this will overide any other settings and ignore any
+        /// this will override any other settings and ignore any
         /// validation checks. If the string is empty it will be
         /// ignored and the existing query builder actions will be
         /// at play.
@@ -43,7 +43,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Sets the Query Alias name. This is used in graphQL to allow
-        /// multipe queries with the same endpoint (name) to be assembled
+        /// multiple queries with the same endpoint (name) to be assembled
         /// into a batch like query. This will prefix the Name in the query.
         /// It will also be used for the Response name processing.
         /// Note that this can be applied to any sub-select as well. GraphQL will
@@ -58,7 +58,7 @@ namespace Carlabs.Getit
         /// and add it to the Select block in the query. GraphQL formatting will
         /// be automatically added. Multi-line comments can be done with the
         /// '\n' character and it will be automatically converted into a GraphQL
-        /// multi-line coment
+        /// multi-line comment
         /// </summary>
         /// <param name="comment">The comment string</param>
         /// <returns>Query</returns>
@@ -104,9 +104,9 @@ namespace Carlabs.Getit
         /// <summary>
         /// Add a dict of key value pairs &lt;string, object&gt; to the existing where part
         /// </summary>
-        /// <param name="dict">An existing Dictionay that takes &lt;string, object&gt;</param>
+        /// <param name="dict">An existing Dictionary that takes &lt;string, object&gt;</param>
         /// <returns>Query</returns>
-        /// <throws>Dupekey and others</throws>
+        /// <throws>DuplicateKeyException and others</throws>
         IQuery Where(Dictionary<string, object> dict);
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Carlabs.Getit
         /// Gets the string representation of the GraphQL query. This does some
         /// MINOR checking and will toss if not formatted correctly
         /// </summary>
-        /// <returns>The GrapQL Query String, without outer enclosing block</returns>
+        /// <returns>The GraphQL Query String, without outer enclosing block</returns>
         /// <throws>ArgumentException</throws>
         string ToString();
     }

--- a/Source/Carlabs.Getit/IQuery.cs
+++ b/Source/Carlabs.Getit/IQuery.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using GraphQL.Common.Response;
 
 namespace Carlabs.Getit
 {
@@ -8,7 +7,6 @@ namespace Carlabs.Getit
     {
         List<object> SelectList { get; }
         Dictionary<string, object> WhereMap { get; }
-        List<GraphQLError> GqlErrors { get; }
         List<IQuery> BatchQueryList { get; }
 
         string QueryName { get; }
@@ -110,14 +108,6 @@ namespace Carlabs.Getit
         /// <returns>Query</returns>
         /// <throws>Dupekey and others</throws>
         IQuery Where(Dictionary<string, object> dict);
-
-        /// <summary>
-        /// Helper to see if any errors were returned with the
-        /// last query. No errors does not mean data, just means
-        /// no errors found in the GQL client results
-        /// </summary>
-        /// <returns>Bool true if errors exist, false if not</returns>
-        bool HasErrors();
 
         /// <summary>
         /// Add additional queries to the request. These

--- a/Source/Carlabs.Getit/IQueryStringBuilder.cs
+++ b/Source/Carlabs.Getit/IQueryStringBuilder.cs
@@ -15,7 +15,7 @@ namespace Carlabs.Getit
         void Clear();
 
         /// <summary>
-        /// Recurses an object which could be a primitive or more
+        /// Recurse an object which could be a primitive or more
         /// complex structure. This will return a string of the value
         /// at the current level. Recursion terminates when at a terminal
         /// (primitive).
@@ -26,7 +26,7 @@ namespace Carlabs.Getit
         string BuildQueryParam(object value);
 
         /// <summary>
-        /// This take all paramter data
+        /// This take all parameter data
         /// and builds the string. This will look in the query and
         /// use the WhereMap for the list of data. The data can be
         /// most any type as long as it's one that we support. Will
@@ -37,7 +37,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Adds fields to the query sting. This will use the SelectList
-        /// structure from the query to build the grapql select list. This
+        /// structure from the query to build the GraphQL select list. This
         /// will recurse as needed to pick up sub-selects that can contain
         /// parameter lists.
         /// </summary>
@@ -47,7 +47,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Adds a comment to the Select list part of the Query. Comments
-        /// may be seperated by a newline and those will expand to individual
+        /// may be separated by a newline and those will expand to individual
         /// comment line. Formatting for graphQL '#' comments will happen here
         /// </summary>
         /// <param name="comments">Simple Comment</param>
@@ -63,7 +63,7 @@ namespace Carlabs.Getit
         /// </summary>
         /// <param name="query">The Query</param>
         /// <param name="indent">Indent characters, default = 0</param>
-        /// <returns>GraphQL query string wihout outer block</returns>
+        /// <returns>GraphQL query string without outer block</returns>
         string Build(IQuery query, int indent = 0);
     }
 }

--- a/Source/Carlabs.Getit/Query.cs
+++ b/Source/Carlabs.Getit/Query.cs
@@ -40,7 +40,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Accepts a string and will use this as the query. Setting
-        /// this will overide any other settings and ignore any
+        /// this will override any other settings and ignore any
         /// validation checks. If the string is empty it will be
         /// ignored and the existing query builder actions will be
         /// at play.
@@ -55,7 +55,7 @@ namespace Carlabs.Getit
         {
             Clear();
 
-            // scan string and find if the first nonwhitespace
+            // scan string and find if the first non-whitespace
             // is a brace, if so we need to strip beginning and
             // ending. Otherwise leave it be.
 
@@ -104,7 +104,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Sets the Query Alias name. This is used in graphQL to allow
-        /// multipe queries with the same endpoint (name) to be assembled
+        /// multiple queries with the same endpoint (name) to be assembled
         /// into a batch like query. This will prefix the Name as specified.
         /// Note that this can be applied to any sub-select as well. GraphQL will
         /// rename the query with the alias name in the response.
@@ -123,7 +123,7 @@ namespace Carlabs.Getit
         /// and add it to the Select block in the query. GraphQL formatting will
         /// be automatically added. Multi-line comments can be done with the
         /// '\n' character and it will be automatically converted into a GraphQL
-        /// multi-line coment
+        /// multi-line comment
         /// </summary>
         /// <param name="comment">The comment string</param>
         /// <returns>Query</returns>
@@ -199,7 +199,7 @@ namespace Carlabs.Getit
         /// <summary>
         /// Add a dict of key value pairs &lt;string, object&gt; to the existing where part
         /// </summary>
-        /// <param name="dict">An existing Dictionay that takes &lt;string, object&gt;</param>
+        /// <param name="dict">An existing Dictionary that takes &lt;string, object&gt;</param>
         /// <returns>Query</returns>
         /// <exception cref="ArgumentException">Dupe Key</exception>
         /// <exception cref="ArgumentNullException">Null Argument</exception>

--- a/Source/Carlabs.Getit/Query.cs
+++ b/Source/Carlabs.Getit/Query.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using GraphQL.Common.Response;
 
 namespace Carlabs.Getit
 {
@@ -9,8 +8,7 @@ namespace Carlabs.Getit
     /// The Query Class is a simple class to build out graphQL
     /// style queries. It will build the parameters and field lists
     /// similar in a way you would use a SQL query builder to assemble
-    /// a query. This will maintain the response and errors for the
-    /// query.
+    /// a query. This will maintain the response for the query
     /// </summary>
     public class Query : IQuery
     {
@@ -22,7 +20,6 @@ namespace Carlabs.Getit
         public string RawQuery { get; private set; }
         public List<IQuery> BatchQueryList { get; } = new List<IQuery>();
         public IQueryStringBuilder Builder { get; } = new QueryStringBuilder();
-        public List<GraphQLError> GqlErrors { get; } = new List<GraphQLError>();
 
         /// <summary>
         /// Clear the Query and anything related
@@ -38,7 +35,6 @@ namespace Carlabs.Getit
             AliasName = string.Empty;
             QueryComment = string.Empty;
             RawQuery = string.Empty;
-            GqlErrors.Clear();
             BatchQueryList.Clear();
         }
 
@@ -213,19 +209,6 @@ namespace Carlabs.Getit
                 WhereMap.Add(field.Key, field.Value);
 
             return this;
-        }
-
-        /// <summary>
-        /// Helper to see if any errors were returned with the
-        /// last query. No errors does not mean data, just means
-        /// no errors found in the GQL client results. Errors and the
-        /// thus this count will persis until cleared or the query
-        /// is executed.
-        /// </summary>
-        /// <returns>Bool true if errors exist, false if not</returns>
-        public bool HasErrors()
-        {
-            return GqlErrors.Count > 0;
         }
 
         /// <summary>

--- a/Source/Carlabs.Getit/QueryStringBuilder.cs
+++ b/Source/Carlabs.Getit/QueryStringBuilder.cs
@@ -9,10 +9,10 @@ namespace Carlabs.Getit
 {
     /// <summary>
     /// Builds a GraphQL query from the Query Object. For parameters it
-    /// support simple paramaters, ENUMs, Lists, and Objects.
+    /// support simple parameters, ENUMs, Lists, and Objects.
     /// For selections fields it supports sub-selects with params as above.
     ///
-    /// Most all sturctures can be recursive, and are unwound as needed
+    /// Most all structures can be recursive, and are unwound as needed
     ///
     /// </summary>
     public class QueryStringBuilder : IQueryStringBuilder
@@ -34,7 +34,7 @@ namespace Carlabs.Getit
         }
 
         /// <summary>
-        /// Recurses an object which could be a primitive or more
+        /// Recurse an object which could be a primitive or more
         /// complex structure. This will return a string of the value
         /// at the current level. Recursion terminates when at a terminal
         /// (primitive).
@@ -66,7 +66,7 @@ namespace Carlabs.Getit
                     return enumValue.ToString();
 
                 // All below are non-primitives that will recurse
-                // until the structure resloves into primitives
+                // until the structure resolves into primitives
 
                 case KeyValuePair<string, object> kvValue:
                     StringBuilder keyValueStr = new StringBuilder();
@@ -166,7 +166,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Adds fields to the query sting. This will use the SelectList
-        /// structure from the query to build the grapql select list. This
+        /// structure from the query to build the graphql select list. This
         /// will recurse as needed to pick up sub-selects that can contain
         /// parameter lists.
         /// </summary>
@@ -188,9 +188,9 @@ namespace Carlabs.Getit
                     case string _:
                         QueryString.Append(strPad + $"{field}\n");
                         break;
-                    case Query _:
+                    case Query query1:
                         QueryStringBuilder subQuery = new QueryStringBuilder();
-                        QueryString.Append($"{subQuery.Build((Query)field, indent)}\n");
+                        QueryString.Append($"{subQuery.Build(query1, indent)}\n");
                         break;
                     default:
                         throw new ArgumentException("Invalid Field Type Specified, must be `string` or `Query`");
@@ -200,7 +200,7 @@ namespace Carlabs.Getit
 
         /// <summary>
         /// Adds a comment to the Select list part of the Query. Comments
-        /// may be seperated by a newline and those will expand to individual
+        /// may be separated by a newline and those will expand to individual
         /// comment line. Formatting for graphQL '#' comments will happen here
         /// </summary>
         /// <param name="comments">Simple Comment</param>
@@ -224,7 +224,7 @@ namespace Carlabs.Getit
         /// </summary>
         /// <param name="query">The Query</param>
         /// <param name="indent">Indent characters, default = 0</param>
-        /// <returns>GraphQL query string wihout outer block</returns>
+        /// <returns>GraphQL query string without outer block</returns>
         public string Build(IQuery query, int indent = 0)
         {
             string pad = new String(' ', indent);

--- a/Tests/Carlabs.Getit.IntegrationTests/GetitTests.cs
+++ b/Tests/Carlabs.Getit.IntegrationTests/GetitTests.cs
@@ -96,7 +96,7 @@ namespace Carlabs.Getit.IntegrationTests
             // Add that subselect to the main select
             List<object> selList = new List<object>(new object[] { "id", subSelect, "name", "make", "model" });
 
-            // List of ints (IDs)
+            // List of int's (IDs)
             List<int> trimList = new List<int>(new[] { 143783, 243784, 343145 });
 
             // String List

--- a/Tests/Carlabs.Getit.UnitTests/QueryTests.cs
+++ b/Tests/Carlabs.Getit.UnitTests/QueryTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using GraphQL.Common.Response;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -368,19 +367,6 @@ namespace Carlabs.Getit.UnitTests
             Assert.AreEqual(expectedRawQuery, query.RawQuery);
             Assert.AreEqual(expectedRawQuery, query.ToString());
             Assert.AreEqual(string.Empty, query.QueryName);
-        }
-
-        [TestMethod]
-        public void Check_Error_Exists()
-        {
-            IQuery query = new Query();
-
-            // add an empty error to mess with things
-            query.GqlErrors.Add(new GraphQLError());
-
-            // Query query = new Query(queryStringBuilder, config);
-
-            Assert.IsTrue(query.HasErrors());
         }
     }
 }


### PR DESCRIPTION
Updated the Get() method to now not return NULL on return of missing data, or other related errors. All errors now will throw an exception. Additional data (query, GraphQLError) will be bundled back into the exception data. 

If the exception happens during the call, the GraphQLClient exception will be thrown directly and not caught. No additional data is bundled for this.

For situation where their is missing or GraphQLErrors the query and the GraphQLErrors will be bundled back into the exceptions data with the following keys -

`request`  as a String
`gqlErrors` as an Array of GraphQLError

You must check existence of these prior to using with this mechanism -

```
...
catch(Exception ex)
{
    if (ex.Data.Contains("request"))
    {
        // look at the graphql request string
        string gqlRequest = ex.Data["request"]
    }

   if (ex.Data.Contains("gqlErrors")
   {
        // look at the GraphQLErrors array. Note this is not a string and should be
        // accessed like -
        GraphQLError[] gqlErrors = (GraphQLError[])ex.Data["gqlErrors"];
        foreach (GraphQLError gqlError in gqlErrors)
        {
               string message = gqlError.Message;
               // etc
        }
    }
}
```